### PR TITLE
Implement YouTube download flow using yt-dlp-exec

### DIFF
--- a/app/api/download/route.ts
+++ b/app/api/download/route.ts
@@ -1,19 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
+import os from "os";
+import path from "path";
+import { downloadVideo } from "@/lib/downloader";
+
+function isValidYouTubeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+
+    return (
+      host === "youtube.com" ||
+      host === "www.youtube.com" ||
+      host === "m.youtube.com" ||
+      host === "youtu.be"
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * POST /api/download
  * Body: { url: string }
  *
- * Downloads a YouTube video using yt-dlp and returns the local file path.
- * TODO: Implement yt-dlp integration.
+ * Downloads a YouTube video and returns the local file path.
  */
 export async function POST(req: NextRequest) {
-  const { url } = await req.json();
+  try {
+    const body = await req.json();
+    const url = body?.url;
 
-  if (!url) {
-    return NextResponse.json({ error: "Missing YouTube URL" }, { status: 400 });
+    if (typeof url !== "string" || !url.trim()) {
+      return NextResponse.json({ error: "Missing YouTube URL" }, { status: 400 });
+    }
+
+    if (!isValidYouTubeUrl(url)) {
+      return NextResponse.json({ error: "Invalid YouTube URL" }, { status: 400 });
+    }
+
+    const outputDir = path.join(os.tmpdir(), "clipengine-downloads");
+    const filePath = await downloadVideo(url, outputDir);
+
+    return NextResponse.json({ filePath });
+  } catch (error) {
+    console.error("Video download failed:", error);
+
+    const message = error instanceof Error ? error.message : "Failed to download video";
+
+    return NextResponse.json(
+      { error: message || "Failed to download video" },
+      { status: 500 },
+    );
   }
-
-  // TODO: Spawn yt-dlp process, download to /tmp, return file path
-  return NextResponse.json({ message: "Download endpoint stub", url });
 }

--- a/lib/downloader.ts
+++ b/lib/downloader.ts
@@ -1,24 +1,56 @@
 import ytDlp from "yt-dlp-exec";
+import fs from "fs/promises";
 import path from "path";
-import os from "os";
+
+function isValidYouTubeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+
+    return (
+      host === "youtube.com" ||
+      host === "www.youtube.com" ||
+      host === "m.youtube.com" ||
+      host === "youtu.be"
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
- * Downloads a YouTube video to a temporary directory using yt-dlp.
+ * Downloads a YouTube video to the provided directory using yt-dlp.
  *
  * @param url - The YouTube video URL
- * @returns The local file path of the downloaded video
+ * @param outputDir - The directory where the downloaded file should be saved
+ * @returns The absolute local file path of the downloaded video
  */
-export async function downloadVideo(url: string): Promise<string> {
-  const outputDir = os.tmpdir();
-  const outputTemplate = path.join(outputDir, "%(id)s.%(ext)s");
+export async function downloadVideo(url: string, outputDir: string): Promise<string> {
+  if (!isValidYouTubeUrl(url)) {
+    throw new Error("Invalid YouTube URL");
+  }
 
-  // TODO: Capture the actual output filename from yt-dlp stdout
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const metadata = await ytDlp(url, {
+    dumpSingleJson: true,
+    skipDownload: true,
+    noWarnings: true,
+    noPlaylist: true,
+  });
+
+  if (!metadata?.id) {
+    throw new Error("Failed to resolve YouTube video ID");
+  }
+
+  const outputTemplate = path.join(outputDir, `${metadata.id}.%(ext)s`);
+
   await ytDlp(url, {
     output: outputTemplate,
-    format: "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+    noPlaylist: true,
+    format: "bestvideo+bestaudio/best",
     mergeOutputFormat: "mp4",
   });
 
-  // Placeholder: return expected path; improve with actual filename resolution
-  return outputDir;
+  return path.resolve(outputDir, `${metadata.id}.mp4`);
 }


### PR DESCRIPTION
### Motivation

- Add a server API to download YouTube videos and return a predictable local file path so downstream code can consume the downloaded MP4.
- Use `yt-dlp-exec` to ensure best-quality video+audio are downloaded and merged to a single MP4 file named by the YouTube `video_id`.

### Description

- Implemented `downloadVideo(url, outputDir)` in `lib/downloader.ts` which validates the URL with `isValidYouTubeUrl`, ensures `outputDir` exists, fetches metadata via `dumpSingleJson`/`skipDownload` to resolve a stable `metadata.id`, downloads `bestvideo+bestaudio/best` and uses `mergeOutputFormat: "mp4"`, then returns the absolute path `<outputDir>/<video_id>.mp4`.
- Added URL validation and explicit error throws for invalid URLs and failed metadata resolution inside `downloadVideo`.
- Implemented the `POST` handler at `app/api/download/route.ts` which parses `{ url }` from the JSON body, validates the URL, calls `downloadVideo` using `path.join(os.tmpdir(), "clipengine-downloads")`, and returns `{ filePath }` on success.
- Added structured error handling in the API to return `400` for missing/invalid URLs and `500` with an error message for download/runtime failures.

### Testing

- Ran type-checking with `npx tsc --noEmit`, which completed successfully.
- Ran `npm run lint`, which failed due to the repository using `next.config.ts` that is not supported by the current Next.js lint loader (this is an existing project config issue and unrelated to the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b85d19b1808330a48b82eb88ab49a4)