### PR TITLE
Add YouTube download and Shorts clipping endpoints with yt-dlp and ffmpeg integration

### DIFF
--- a/app/api/clip/route.ts
+++ b/app/api/clip/route.ts
@@ -1,27 +1,74 @@
 import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import { clipToShorts } from "@/lib/ffmpeg";
+
+type ClipBody = {
+  filePath?: unknown;
+  startTime?: unknown;
+  duration?: unknown;
+};
 
 /**
  * POST /api/clip
- * Body: { filePath: string; startTime: number; endTime: number }
+ * Body: { filePath: string; startTime: number; duration: number }
  *
- * Uses ffmpeg to clip the video to a vertical 9:16 Shorts-ready format.
- * TODO: Implement ffmpeg integration.
+ * Clips the video to a vertical 9:16 Shorts-ready format.
  */
 export async function POST(req: NextRequest) {
-  const { filePath, startTime, endTime } = await req.json();
+  try {
+    const body = (await req.json()) as ClipBody;
+    const filePath = body?.filePath;
+    const startTime = body?.startTime;
+    const duration = body?.duration;
 
-  if (!filePath || startTime === undefined || endTime === undefined) {
+    if (typeof filePath !== "string" || !filePath.trim()) {
+      return NextResponse.json(
+        { error: "Missing or invalid filePath" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof startTime !== "number" || !Number.isFinite(startTime) || startTime < 0) {
+      return NextResponse.json(
+        { error: "startTime must be a non-negative number" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof duration !== "number" || !Number.isFinite(duration) || duration <= 0) {
+      return NextResponse.json(
+        { error: "duration must be a positive number" },
+        { status: 400 },
+      );
+    }
+
+    const absoluteInputPath = path.resolve(filePath);
+
+    try {
+      await fs.access(absoluteInputPath);
+    } catch {
+      return NextResponse.json(
+        { error: "Input file does not exist or is not accessible" },
+        { status: 400 },
+      );
+    }
+
+    const parsed = path.parse(absoluteInputPath);
+    const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const clippedFilePath = path.join(parsed.dir, `${parsed.name}_clipped_${uniqueSuffix}.mp4`);
+
+    await clipToShorts(absoluteInputPath, clippedFilePath, startTime, duration);
+
+    return NextResponse.json({ clippedFilePath });
+  } catch (error) {
+    console.error("Video clipping failed:", error);
+
+    const message = error instanceof Error ? error.message : "Failed to clip video";
+
     return NextResponse.json(
-      { error: "Missing filePath, startTime, or endTime" },
-      { status: 400 }
+      { error: message || "Failed to clip video" },
+      { status: 500 },
     );
   }
-
-  // TODO: Use fluent-ffmpeg to crop, resize to 9:16, and trim the clip
-  return NextResponse.json({
-    message: "Clip endpoint stub",
-    filePath,
-    startTime,
-    endTime,
-  });
 }

--- a/app/api/download/route.ts
+++ b/app/api/download/route.ts
@@ -1,19 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
+import os from "os";
+import path from "path";
+import { downloadVideo } from "@/lib/downloader";
+
+function isValidYouTubeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+
+    return (
+      host === "youtube.com" ||
+      host === "www.youtube.com" ||
+      host === "m.youtube.com" ||
+      host === "youtu.be"
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * POST /api/download
  * Body: { url: string }
  *
- * Downloads a YouTube video using yt-dlp and returns the local file path.
- * TODO: Implement yt-dlp integration.
+ * Downloads a YouTube video and returns the local file path.
  */
 export async function POST(req: NextRequest) {
-  const { url } = await req.json();
+  try {
+    const body = await req.json();
+    const url = body?.url;
 
-  if (!url) {
-    return NextResponse.json({ error: "Missing YouTube URL" }, { status: 400 });
+    if (typeof url !== "string" || !url.trim()) {
+      return NextResponse.json({ error: "Missing YouTube URL" }, { status: 400 });
+    }
+
+    if (!isValidYouTubeUrl(url)) {
+      return NextResponse.json({ error: "Invalid YouTube URL" }, { status: 400 });
+    }
+
+    const outputDir = path.join(os.tmpdir(), "clipengine-downloads");
+    const filePath = await downloadVideo(url, outputDir);
+
+    return NextResponse.json({ filePath });
+  } catch (error) {
+    console.error("Video download failed:", error);
+
+    const message = error instanceof Error ? error.message : "Failed to download video";
+
+    return NextResponse.json(
+      { error: message || "Failed to download video" },
+      { status: 500 },
+    );
   }
-
-  // TODO: Spawn yt-dlp process, download to /tmp, return file path
-  return NextResponse.json({ message: "Download endpoint stub", url });
 }

--- a/lib/downloader.ts
+++ b/lib/downloader.ts
@@ -1,24 +1,56 @@
 import ytDlp from "yt-dlp-exec";
+import fs from "fs/promises";
 import path from "path";
-import os from "os";
+
+function isValidYouTubeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+
+    return (
+      host === "youtube.com" ||
+      host === "www.youtube.com" ||
+      host === "m.youtube.com" ||
+      host === "youtu.be"
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
- * Downloads a YouTube video to a temporary directory using yt-dlp.
+ * Downloads a YouTube video to the provided directory using yt-dlp.
  *
  * @param url - The YouTube video URL
- * @returns The local file path of the downloaded video
+ * @param outputDir - The directory where the downloaded file should be saved
+ * @returns The absolute local file path of the downloaded video
  */
-export async function downloadVideo(url: string): Promise<string> {
-  const outputDir = os.tmpdir();
-  const outputTemplate = path.join(outputDir, "%(id)s.%(ext)s");
+export async function downloadVideo(url: string, outputDir: string): Promise<string> {
+  if (!isValidYouTubeUrl(url)) {
+    throw new Error("Invalid YouTube URL");
+  }
 
-  // TODO: Capture the actual output filename from yt-dlp stdout
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const metadata = await ytDlp(url, {
+    dumpSingleJson: true,
+    skipDownload: true,
+    noWarnings: true,
+    noPlaylist: true,
+  });
+
+  if (!metadata?.id) {
+    throw new Error("Failed to resolve YouTube video ID");
+  }
+
+  const outputTemplate = path.join(outputDir, `${metadata.id}.%(ext)s`);
+
   await ytDlp(url, {
     output: outputTemplate,
-    format: "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+    noPlaylist: true,
+    format: "bestvideo+bestaudio/best",
     mergeOutputFormat: "mp4",
   });
 
-  // Placeholder: return expected path; improve with actual filename resolution
-  return outputDir;
+  return path.resolve(outputDir, `${metadata.id}.mp4`);
 }

--- a/lib/ffmpeg.ts
+++ b/lib/ffmpeg.ts
@@ -12,14 +12,25 @@ export function clipToShorts(
   inputPath: string,
   outputPath: string,
   startTime: number,
-  duration: number
+  duration: number,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    // TODO: Add crop filter for 9:16 aspect ratio based on source dimensions
+    if (!Number.isFinite(startTime) || startTime < 0) {
+      reject(new Error("startTime must be a non-negative number"));
+      return;
+    }
+
+    if (!Number.isFinite(duration) || duration <= 0) {
+      reject(new Error("duration must be a positive number"));
+      return;
+    }
+
+    const clippedDuration = Math.min(duration, 60);
+
     ffmpeg(inputPath)
       .setStartTime(startTime)
-      .setDuration(Math.min(duration, 60))
-      .videoFilters("crop=ih*9/16:ih") // center-crop to 9:16
+      .setDuration(clippedDuration)
+      .videoFilters("crop=ih*9/16:ih")
       .output(outputPath)
       .on("end", () => resolve())
       .on("error", (err) => reject(err))


### PR DESCRIPTION
### Motivation

- Provide server endpoints to download YouTube videos and produce vertical 9:16 Shorts-ready clips rather than stubs. 
- Validate inputs and surface clear errors for missing/invalid URLs, file paths, and time parameters.

### Description

- Implemented `/api/download` to validate YouTube URLs, create a temporary output dir using `os.tmpdir()`, and call `downloadVideo(url, outputDir)` which uses `yt-dlp-exec` to fetch metadata and download the video to an `{id}.mp4` file. 
- Implemented `/api/clip` to validate `filePath`, `startTime`, and `duration`, ensure the input file is accessible via `fs.access`, generate a unique output filename, and call `clipToShorts(inputPath, outputPath, startTime, duration)`. 
- Extended `lib/downloader.ts` to accept an `outputDir`, validate the YouTube URL, create the directory, query metadata with `yt-dlp-exec` (`dumpSingleJson`) to derive the output template, and return the resolved `{id}.mp4` path. 
- Enhanced `lib/ffmpeg.ts` `clipToShorts` to validate `startTime` and `duration`, cap duration to 60 seconds, apply a center-crop `videoFilters("crop=ih*9/16:ih")`, and reject with meaningful errors on invalid input. 

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b85d19b1808330a48b82eb88ab49a4)